### PR TITLE
feat : MainScene Player Sprite Update (#34)

### DIFF
--- a/PPONGARI/Assets/Scenes/MainScene.unity
+++ b/PPONGARI/Assets/Scenes/MainScene.unity
@@ -2928,8 +2928,9 @@ GameObject:
   - component: {fileID: 1727607741}
   - component: {fileID: 1727607740}
   - component: {fileID: 1727607739}
-  - component: {fileID: 1727607742}
   - component: {fileID: 1727607743}
+  - component: {fileID: 1727607744}
+  - component: {fileID: 1727607745}
   m_Layer: 0
   m_Name: Player
   m_TagString: Untagged
@@ -3005,7 +3006,7 @@ SpriteRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
-  m_Sprite: {fileID: -9095717837082945937, guid: 207ee8102dd4143d288186ef0be518ee, type: 3}
+  m_Sprite: {fileID: 528725502, guid: 17055aa4acad78c43afa6d46c666a132, type: 3}
   m_Color: {r: 0.9763818, g: 1, b: 0.56981134, a: 1}
   m_FlipX: 0
   m_FlipY: 0
@@ -3026,13 +3027,26 @@ Transform:
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: -8.1636, y: -1.1472, z: 0}
-  m_LocalScale: {x: 0.7528, y: 0.7528, z: 0.7528}
-  m_ConstrainProportionsScale: 0
+  m_LocalScale: {x: 1.5, y: 1.5, z: 1.5}
+  m_ConstrainProportionsScale: 1
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!70 &1727607742
-CapsuleCollider2D:
+--- !u!114 &1727607743
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1727607738}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 50c00468d4fe30f4ea5b564a642d1e86, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  speed: 5
+--- !u!58 &1727607744
+CircleCollider2D:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -3064,21 +3078,29 @@ CapsuleCollider2D:
   m_UsedByEffector: 0
   m_UsedByComposite: 0
   m_Offset: {x: 0, y: 0}
-  m_Size: {x: 1, y: 2}
-  m_Direction: 0
---- !u!114 &1727607743
-MonoBehaviour:
+  serializedVersion: 2
+  m_Radius: 0.32
+--- !u!95 &1727607745
+Animator:
+  serializedVersion: 5
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1727607738}
   m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 50c00468d4fe30f4ea5b564a642d1e86, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  speed: 5
+  m_Avatar: {fileID: 0}
+  m_Controller: {fileID: 9100000, guid: d70c7243edb4fb145a05e580a6c65c9f, type: 2}
+  m_CullingMode: 0
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorStateOnDisable: 0
+  m_WriteDefaultValuesOnDisable: 0
 --- !u!1 &1779442941
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
# PR을 하기 전 체크사항

- [x] 임시로 작성한 코드는 모두 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 실행했을 때, 오류는 없나요?
- [x] 커밋 메시지는 [가이드](https://docs.google.com/document/d/1bDgWctGEprMvLzV5OpuZV1-BCnrhVVJ19cd8D9tFArU/edit#heading=h.jgj6vfjils4q)에 맞춰 작성됐나요?

# 변경된 기능
달라진 기능에는 무엇이 있는지 목록으로 작성합니다. 이번 작업 내용을 통해 할 수 있는 기능 및 행동 등을 설명해주세요.

- MainScene의 Player Sprite를 변경함.
- Player의 Transform Scale은 1.5로 변경함.
- State의 Entry는 PlayerIdle.

# 제안 사항

- MainScene의 Player Sprite를 변경
> Player의 Animation을 적용해보기위함.
- Player의 Transform Scale은 1.5로 변경
> 화면 비율 대비 1.5의 Scale이 적당하다고 판단함.
-  State의 Entry는 PlayerIdle
> PlayerWalk 도 만들었으나 이 부분은 스크립트 작성이 필요함.

# 스크린샷 <!--여기 스크린샷 첨부하고 (선택) 이거는 지워주세요-->

https://github.com/Gongju-Unity-Bootcamp/HANDSOMEDINO/assets/102023674/e8e069d9-7597-40b7-b4d6-ed01928a2e88



# 관련 이슈


- [#34] #{34} <!-- Ex. - [] #763 -->


---

# 코드 리뷰 가이드
코드 리뷰를 어떻게 해야하는지 모르겠다면 아래의 사항을 고려해보세요. 또 [여기](https://blog.banksalad.com/tech/banksalad-code-review-culture/)도 참고해보세요.
